### PR TITLE
Add BlankProfile switch to Launch-Chrome-Plex.ps1

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,4 @@ To use, download the PowerShell script to the machine and create a shortcut to i
 |`.\Launch-Chrome-Plex.ps1 -Product UX -CompanyCode edgeent` | Company-specific UX session for Edge Enterprises |
 |`.\Launch-Chrome-Plex.ps1 -Product Classic` | Classic session |
 
+In addition, you can set the flag `-BlankProfile` to avoid copying the Chrome Default profile. This will remove any favorites, plugins, and other customization from the new session, but does significantly cut down on launch time.

--- a/browsers/Launch-Chrome-Plex.ps1
+++ b/browsers/Launch-Chrome-Plex.ps1
@@ -13,13 +13,17 @@ The product to open (`UX` or `Classic`); defaults to `UX`
 
 .PARAMETER CompanyCode
 The company code, used to generate customer-specific URLs for UX
+
+.PARAMETER BlankProfile
+If set, uses a blank profile rather than copying the Default profile
 #>
 
 [CmdletBinding()]
 Param(
   [ValidateSet("UX", "Classic")]
   [string]$Product = "UX",
-  [string]$CompanyCode = ""
+  [string]$CompanyCode = "",
+  [switch]$BlankProfile = $false
 )
 
 $userData = Join-Path $env:LOCALAPPDATA "\Google\Chrome\User Data\";
@@ -31,7 +35,11 @@ $unixEpoch = (Get-Date 1970-01-01Z).ToUniversalTime();
 $id = [System.Math]::Round([System.DateTime]::Now.ToUniversalTime().Subtract($unixEpoch).TotalSeconds);
 $newDataDir = ($userData + "TempPlexProfile" + $id);
 
-Copy-Item -Path ($userData + "Default\") -Destination $newDataDir -Recurse;
+if ($BlankProfile) {
+  mkdir $newDataDir > $null;
+} else {
+  Copy-Item -Path ($userData + "Default\") -Destination $newDataDir -Recurse;
+}
 
 if ($Product -eq "Classic") {
   $url = "https://www.plexonline.com/signon";


### PR DESCRIPTION
Setting the non-default switch BlankProfile will prevent
the script from using the Default profile associated with
Chrome, causing the app to start almost immediately.

Fixes #4